### PR TITLE
Goal tracking feature and UI modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This is a workout tracking app with:
 - **workouts**: date, user_id
 - **workout_sets**: workout_id, exercise_id, reps, weight
 - **workout_plan**: per-day plan entries (exercise, sets, target reps)
+- **goals**: target 1RM by date per exercise (start 1RM snapshotted at creation)
 
 ### Key env vars
 - `DATABASE_URL` (Postgres)
@@ -160,6 +161,11 @@ npm run build
 ### Plans
 - `GET /api/plan` - Get user's workout plan
 - `POST /api/plan` - Save workout plan
+
+### Goals
+- `GET /api/goals` - Active goals with live progress (current vs expected 1RM)
+- `POST /api/goals` - Create a goal (start 1RM snapshotted automatically)
+- `DELETE /api/goals/:id` - Delete a goal
 
 ## Deployment
 

--- a/backend/lib/oneRm.js
+++ b/backend/lib/oneRm.js
@@ -1,0 +1,55 @@
+// Shared 1RM estimation: Brzycki formula + LOESS smoothing over the
+// daily-max 1RM series. Mirrors the calculation used on the frontend
+// Performance tab so estimates agree everywhere.
+
+const calcOneRm = (weight, reps) => weight / (1.0278 - 0.0278 * reps);
+
+function loess(xs, ys, bandwidth = 0.08) {
+  const n = xs.length;
+  const bw = Math.max(2, Math.floor(bandwidth * n));
+  const result = [];
+  for (let i = 0; i < n; i++) {
+    const distances = xs.map(x => Math.abs(x - xs[i]));
+    const idxs = distances
+      .map((d, idx) => [d, idx])
+      .sort((a, b) => a[0] - b[0])
+      .slice(0, bw)
+      .map(pair => pair[1]);
+    const xw = idxs.map(j => xs[j]);
+    const yw = idxs.map(j => ys[j]);
+    const xbar = xw.reduce((a, b) => a + b, 0) / bw;
+    const ybar = yw.reduce((a, b) => a + b, 0) / bw;
+    const num = xw.reduce((sum, xj, k) => sum + (xj - xbar) * (yw[k] - ybar), 0);
+    const den = xw.reduce((sum, xj) => sum + (xj - xbar) ** 2, 0);
+    const beta = den === 0 ? 0 : num / den;
+    const alpha = ybar - beta * xbar;
+    result.push([xs[i], alpha + beta * xs[i]]);
+  }
+  return result;
+}
+
+// rows: [{ date: Date|string, weight, reps }] ordered by date ascending.
+// Returns the LOESS-smoothed estimate of current 1RM (0 if no data).
+function estimateCurrentOneRm(rows) {
+  if (!rows || rows.length === 0) return 0;
+  const points = rows.map(set => ({
+    date: (typeof set.date === 'string') ? set.date.slice(0, 10) : set.date.toISOString().slice(0, 10),
+    one_rm: calcOneRm(set.weight, set.reps),
+  }));
+  const byDate = {};
+  points.forEach(pt => {
+    if (!byDate[pt.date] || pt.one_rm > byDate[pt.date].one_rm) {
+      byDate[pt.date] = pt;
+    }
+  });
+  const dailyMax = Object.values(byDate).sort((a, b) => a.date.localeCompare(b.date));
+  if (dailyMax.length >= 3) {
+    const xs = dailyMax.map(pt => new Date(pt.date).getTime());
+    const ys = dailyMax.map(pt => pt.one_rm);
+    const line = loess(xs, ys, 0.08);
+    return line[line.length - 1][1];
+  }
+  return dailyMax[dailyMax.length - 1].one_rm;
+}
+
+module.exports = { calcOneRm, loess, estimateCurrentOneRm };

--- a/backend/routes/goals.js
+++ b/backend/routes/goals.js
@@ -1,0 +1,131 @@
+const express = require('express');
+const { pool } = require('../database.pg');
+const authenticateToken = require('./authMiddleware');
+const { estimateCurrentOneRm } = require('../lib/oneRm');
+const router = express.Router();
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const toDateString = (d) =>
+  (typeof d === 'string') ? d.slice(0, 10) : d.toISOString().slice(0, 10);
+
+// Expected 1RM today: linear interpolation between start and target,
+// clamped to the goal window.
+function expectedOneRm(goal, now = new Date()) {
+  const start = new Date(toDateString(goal.start_date)).getTime();
+  const end = new Date(toDateString(goal.target_date)).getTime();
+  const t = Math.min(Math.max(now.getTime(), start), end);
+  const span = end - start;
+  const frac = span <= 0 ? 1 : (t - start) / span;
+  return goal.start_one_rm + (goal.target_one_rm - goal.start_one_rm) * frac;
+}
+
+async function currentOneRmFor(userId, exerciseId) {
+  const result = await pool.query(
+    'SELECT w.date, ws.weight, ws.reps FROM workout_sets ws JOIN workouts w ON ws.workout_id = w.id WHERE ws.user_id = $1 AND ws.exercise_id = $2 ORDER BY w.date ASC, ws.set_number ASC',
+    [userId, exerciseId]
+  );
+  return estimateCurrentOneRm(result.rows);
+}
+
+// GET all active goals with live progress
+router.get('/', authenticateToken, async (req, res) => {
+  const userId = req.user.userId;
+  try {
+    const result = await pool.query(
+      `SELECT g.*, e.name AS exercise_name, e.muscle_group
+       FROM goals g JOIN exercises e ON g.exercise_id = e.id
+       WHERE g.user_id = $1 AND g.status = 'active'
+       ORDER BY g.target_date ASC`,
+      [userId]
+    );
+    const goals = await Promise.all(result.rows.map(async (goal) => {
+      const current = await currentOneRmFor(userId, goal.exercise_id);
+      const expected = expectedOneRm(goal);
+      const span = goal.target_one_rm - goal.start_one_rm;
+      const progress = span === 0 ? 1 : (current - goal.start_one_rm) / span;
+      // Small tolerance so a freshly created goal isn't instantly "behind"
+      const tolerance = Math.max(0.5, Math.abs(span) * 0.05);
+      return {
+        ...goal,
+        start_date: toDateString(goal.start_date),
+        target_date: toDateString(goal.target_date),
+        current_one_rm: Math.round(current * 10) / 10,
+        expected_one_rm: Math.round(expected * 10) / 10,
+        progress: Math.min(Math.max(progress, 0), 1),
+        on_track: current >= expected - tolerance,
+        achieved: current >= goal.target_one_rm,
+      };
+    }));
+    res.json(goals);
+  } catch (err) {
+    console.error('Error fetching goals:', err);
+    res.status(500).json({ error: 'Failed to fetch goals' });
+  }
+});
+
+// POST create a goal. start_one_rm is snapshotted from the current
+// LOESS estimate so progress is measured from where the user is now.
+router.post('/', authenticateToken, async (req, res) => {
+  const userId = req.user.userId;
+  const { exercise_id, target_one_rm, target_date } = req.body;
+  if (!exercise_id || !target_one_rm || !target_date) {
+    return res.status(400).json({ error: 'exercise_id, target_one_rm and target_date are required' });
+  }
+  const target = parseFloat(target_one_rm);
+  if (!Number.isFinite(target) || target <= 0) {
+    return res.status(400).json({ error: 'target_one_rm must be a positive number' });
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(target_date) || Number.isNaN(new Date(target_date).getTime())) {
+    return res.status(400).json({ error: 'target_date must be YYYY-MM-DD' });
+  }
+  const today = new Date().toISOString().slice(0, 10);
+  if (target_date <= today) {
+    return res.status(400).json({ error: 'target_date must be in the future' });
+  }
+  try {
+    const existing = await pool.query(
+      "SELECT id FROM goals WHERE user_id = $1 AND exercise_id = $2 AND status = 'active'",
+      [userId, exercise_id]
+    );
+    if (existing.rows.length > 0) {
+      return res.status(409).json({ error: 'An active goal already exists for this exercise' });
+    }
+    const current = await currentOneRmFor(userId, exercise_id);
+    if (!current || current <= 0) {
+      return res.status(400).json({ error: 'Log some sets for this exercise first so a starting 1RM can be estimated' });
+    }
+    if (target <= current) {
+      return res.status(400).json({ error: `Target must be above your current estimated 1RM (${Math.round(current * 10) / 10} kg)` });
+    }
+    const result = await pool.query(
+      `INSERT INTO goals (user_id, exercise_id, start_date, target_date, start_one_rm, target_one_rm)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [userId, exercise_id, today, target_date, Math.round(current * 10) / 10, target]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    console.error('Error creating goal:', err);
+    res.status(500).json({ error: 'Failed to create goal' });
+  }
+});
+
+// DELETE a goal
+router.delete('/:id', authenticateToken, async (req, res) => {
+  const userId = req.user.userId;
+  try {
+    const result = await pool.query(
+      'DELETE FROM goals WHERE id = $1 AND user_id = $2',
+      [req.params.id, userId]
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Goal not found' });
+    }
+    res.json({ message: 'Goal deleted' });
+  } catch (err) {
+    console.error('Error deleting goal:', err);
+    res.status(500).json({ error: 'Failed to delete goal' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { pool } = require('../database.pg');
 const authenticateToken = require('./authMiddleware');
+const { estimateCurrentOneRm } = require('../lib/oneRm');
 const router = express.Router();
 
 // One rep max uses the Brzycki formula: weight / (1.0278 - 0.0278 * reps),
@@ -352,55 +353,7 @@ router.get('/suggested-weights', authenticateToken, async (req, res) => {
         }
       });
     }
-    // Calculate 1RM for each set
-    const points = result.rows.map(set => ({
-      date: (typeof set.date === 'string') ? set.date : set.date.toISOString().slice(0, 10),
-      one_rm: set.weight / (1.0278 - 0.0278 * set.reps)
-    }));
-    // Get daily max 1RM (one per date)
-    const byDate = {};
-    points.forEach(pt => {
-      const dateOnly = pt.date.slice(0, 10);
-      if (!byDate[dateOnly] || pt.one_rm > byDate[dateOnly].one_rm) {
-        byDate[dateOnly] = { ...pt, date: dateOnly };
-      }
-    });
-    const dailyMax = Object.values(byDate).sort((a, b) => a.date.localeCompare(b.date));
-    // LOESS smoothing (same as performance tab)
-    function loess(xs, ys, bandwidth = 0.08) {
-      const n = xs.length;
-      const bw = Math.max(2, Math.floor(bandwidth * n));
-      const result = [];
-      for (let i = 0; i < n; i++) {
-        const distances = xs.map(x => Math.abs(x - xs[i]));
-        const idxs = distances
-          .map((d, idx) => [d, idx])
-          .sort((a, b) => a[0] - b[0])
-          .slice(0, bw)
-          .map(pair => pair[1]);
-        const xw = idxs.map(j => xs[j]);
-        const yw = idxs.map(j => ys[j]);
-        const xbar = xw.reduce((a, b) => a + b, 0) / bw;
-        const ybar = yw.reduce((a, b) => a + b, 0) / bw;
-        const num = xw.reduce((sum, xj, k) => sum + (xj - xbar) * (yw[k] - ybar), 0);
-        const den = xw.reduce((sum, xj) => sum + (xj - xbar) ** 2, 0);
-        const beta = den === 0 ? 0 : num / den;
-        const alpha = ybar - beta * xbar;
-        result.push([xs[i], alpha + beta * xs[i]]);
-      }
-      return result;
-    }
-    let estimatedOneRepMax = 0;
-    if (dailyMax.length >= 3) {
-      // Use LOESS smoothed value for the latest date
-      const xs = dailyMax.map(pt => new Date(pt.date).getTime());
-      const ys = dailyMax.map(pt => pt.one_rm);
-      const loessLine = loess(xs, ys, 0.08);
-      estimatedOneRepMax = loessLine[loessLine.length - 1][1];
-    } else {
-      // Fallback: use latest daily max 1RM
-      estimatedOneRepMax = dailyMax[dailyMax.length - 1].one_rm;
-    }
+    const estimatedOneRepMax = estimateCurrentOneRm(result.rows);
     const newOneRepMax = estimatedOneRepMax + 1;
     const suggestedWeights = {
       reps_3: Math.round((newOneRepMax * (1.02 - (0.02 * 3))) * 10) / 10,

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,7 @@ const exercisesRoutes = require('./routes/exercises');
 const workoutsRoutes = require('./routes/workouts');
 const planRoutes = require('./routes/plan');
 const statsRoutes = require('./routes/stats');
+const goalsRoutes = require('./routes/goals');
 
 const app = express();
 const PORT = process.env.PORT || 5001;
@@ -45,6 +46,7 @@ app.use('/api/exercises', exercisesRoutes);
 app.use('/api/workouts', workoutsRoutes);
 app.use('/api/plan', planRoutes);
 app.use('/api/stats', statsRoutes);
+app.use('/api/goals', goalsRoutes);
 
 // Database connection test
 app.get('/api/health', async (req, res) => {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -14,7 +14,7 @@
     <link rel="apple-touch-icon" sizes="152x152" href="%PUBLIC_URL%/icon-152.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/icon-180.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="WorkoutApp" />
     
     <!-- PWA manifest and icons -->

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,6 +26,7 @@ import Stats from './components/Stats';
 import ExerciseLibrary from './components/ExerciseLibrary';
 import Performance from './components/Performance';
 import WorkoutPlanner from './components/WorkoutPlanner';
+import Goals from './components/Goals';
 import MenuPage from './components/Menu';
 import Login from './components/Login';
 import Register from './components/Register';
@@ -233,6 +234,7 @@ function App() {
             <Route path="/library" element={<ExerciseLibrary />} />
             <Route path="/performance" element={<Performance />} />
             <Route path="/plan" element={<WorkoutPlanner user={user} />} />
+            <Route path="/goals" element={<Goals />} />
             <Route path="/menu" element={<MenuPage user={user} onNavigate={navigate} onLogout={handleLogout} />} />
             <Route path="/login" element={<Login onLogin={handleLogin} switchToRegister={() => setShowRegister(true)} />} />
             <Route path="/register" element={<Register onRegister={handleRegister} switchToLogin={() => setShowRegister(false)} />} />
@@ -253,8 +255,10 @@ function App() {
         <BottomNavigation
           value={value}
           onChange={handleNavigationChange}
-          sx={{ 
-            height: 72
+          sx={{
+            height: 72,
+            pb: 'env(safe-area-inset-bottom)',
+            boxSizing: 'content-box',
           }}
         >
           <BottomNavigationAction

--- a/frontend/src/components/Goals.js
+++ b/frontend/src/components/Goals.js
@@ -1,0 +1,342 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Skeleton,
+  Chip,
+} from '@mui/material';
+import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { format, addWeeks, differenceInCalendarDays, parseISO } from 'date-fns';
+import axios from 'axios';
+import { API_BASE_URL } from '../App';
+import ScrollablePicker from './ScrollablePicker';
+
+const Goals = () => {
+  const [goals, setGoals] = useState([]);
+  const [exercises, setExercises] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [error, setError] = useState('');
+
+  const [formExercise, setFormExercise] = useState('');
+  const [formTarget, setFormTarget] = useState('');
+  const [formDate, setFormDate] = useState(addWeeks(new Date(), 12));
+  const [currentOneRm, setCurrentOneRm] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const fetchGoals = useCallback(async () => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/api/goals`);
+      setGoals(Array.isArray(res.data) ? res.data : []);
+    } catch (err) {
+      console.error('Error fetching goals:', err);
+      setGoals([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGoals();
+    axios.get(`${API_BASE_URL}/api/exercises`)
+      .then(res => setExercises(Array.isArray(res.data) ? res.data : []))
+      .catch(() => setExercises([]));
+  }, [fetchGoals]);
+
+  // Current estimated 1RM for the exercise picked in the create dialog
+  useEffect(() => {
+    if (!formExercise) {
+      setCurrentOneRm(null);
+      return;
+    }
+    let cancelled = false;
+    axios.get(`${API_BASE_URL}/api/stats/suggested-weights?exercise_id=${formExercise}`)
+      .then(res => {
+        if (!cancelled) setCurrentOneRm(res.data?.estimated_one_rep_max || 0);
+      })
+      .catch(() => {
+        if (!cancelled) setCurrentOneRm(0);
+      });
+    return () => { cancelled = true; };
+  }, [formExercise]);
+
+  const groupedExercises = useMemo(() => {
+    if (!exercises.length) return [];
+    const grouped = exercises.reduce((acc, ex) => {
+      const mg = ex.muscle_group || 'Other';
+      if (!acc[mg]) acc[mg] = [];
+      acc[mg].push(ex);
+      return acc;
+    }, {});
+    return Object.keys(grouped).sort().map(mg => ({
+      label: mg,
+      items: grouped[mg].sort((a, b) => a.name.localeCompare(b.name)),
+    }));
+  }, [exercises]);
+
+  const weeklyRate = useMemo(() => {
+    const target = parseFloat(formTarget);
+    if (!currentOneRm || !target || target <= currentOneRm || !formDate) return null;
+    const days = differenceInCalendarDays(formDate, new Date());
+    if (days <= 0) return null;
+    return ((target - currentOneRm) / days) * 7;
+  }, [formTarget, currentOneRm, formDate]);
+
+  const rateLabel = useMemo(() => {
+    if (weeklyRate == null) return null;
+    if (weeklyRate <= 0.75) return { text: 'steady pace', color: '#5DCAA5' };
+    if (weeklyRate <= 1.5) return { text: 'realistic', color: '#5DCAA5' };
+    if (weeklyRate <= 2.5) return { text: 'ambitious', color: '#FAC775' };
+    return { text: 'very aggressive', color: '#F09595' };
+  }, [weeklyRate]);
+
+  const resetForm = () => {
+    setFormExercise('');
+    setFormTarget('');
+    setFormDate(addWeeks(new Date(), 12));
+    setCurrentOneRm(null);
+    setError('');
+  };
+
+  const handleCreate = async () => {
+    if (!formExercise || !formTarget || !formDate) return;
+    try {
+      setSaving(true);
+      setError('');
+      await axios.post(`${API_BASE_URL}/api/goals`, {
+        exercise_id: parseInt(formExercise, 10),
+        target_one_rm: parseFloat(formTarget),
+        target_date: format(formDate, 'yyyy-MM-dd'),
+      });
+      setCreateOpen(false);
+      resetForm();
+      fetchGoals();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to create goal');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await axios.delete(`${API_BASE_URL}/api/goals/${deleteTarget.id}`);
+      setDeleteTarget(null);
+      fetchGoals();
+    } catch (err) {
+      console.error('Error deleting goal:', err);
+      setDeleteTarget(null);
+    }
+  };
+
+  const goalSubtitle = (goal) => {
+    const weeks = Math.max(1, Math.round(differenceInCalendarDays(parseISO(goal.target_date), parseISO(goal.start_date)) / 7));
+    const rate = (goal.target_one_rm - goal.start_one_rm) / weeks;
+    return `${goal.start_one_rm} kg → ${goal.target_one_rm} kg by ${format(parseISO(goal.target_date), 'd MMM')} · ${weeks} wk · +${rate.toFixed(1)} kg/wk`;
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box sx={{ maxWidth: 520, mx: 'auto', mt: 2, px: { xs: 1.5, sm: 0 } }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: 13, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'text.secondary' }}>
+            Goals
+          </Typography>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={() => { resetForm(); setCreateOpen(true); }}
+            sx={{ fontSize: 13, py: 0.5, px: 1.5 }}
+          >
+            New goal
+          </Button>
+        </Box>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Skeleton variant="rounded" height={96} />
+            <Skeleton variant="rounded" height={96} />
+          </Box>
+        ) : goals.length === 0 ? (
+          <Box sx={{ py: 5, textAlign: 'center' }}>
+            <Typography color="text.secondary" sx={{ fontSize: 13, mb: 1 }}>
+              No goals yet
+            </Typography>
+            <Typography color="text.secondary" sx={{ fontSize: 11 }}>
+              Set a target 1RM and a date, and your progress will show here, on the Performance chart, and while you log sets.
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            {goals.map(goal => {
+              const expectedPct = goal.target_one_rm === goal.start_one_rm ? 100 :
+                Math.min(100, Math.max(0, ((goal.expected_one_rm - goal.start_one_rm) / (goal.target_one_rm - goal.start_one_rm)) * 100));
+              return (
+                <Box
+                  key={goal.id}
+                  sx={{
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: 3,
+                    p: 2,
+                    backgroundColor: 'background.paper',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
+                    <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                      {goal.exercise_name}
+                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <Chip
+                        label={goal.achieved ? 'achieved' : goal.on_track ? 'on track' : 'behind'}
+                        size="small"
+                        sx={{
+                          fontSize: 10,
+                          height: 20,
+                          fontWeight: 600,
+                          color: '#04342C',
+                          backgroundColor: goal.achieved ? '#9FE1CB' : goal.on_track ? '#5DCAA5' : '#FAC775',
+                        }}
+                      />
+                      <IconButton size="small" color="error" onClick={() => setDeleteTarget(goal)} sx={{ p: 0.5 }}>
+                        <DeleteIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Box>
+                  </Box>
+                  <Typography color="text.secondary" sx={{ fontSize: 11, mb: 1.5 }}>
+                    {goalSubtitle(goal)}
+                  </Typography>
+                  <Box sx={{ position: 'relative', height: 8, borderRadius: 4, backgroundColor: 'divider', mb: 0.75 }}>
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: `${goal.progress * 100}%`,
+                        borderRadius: 4,
+                        backgroundColor: 'primary.main',
+                        transition: 'width 0.4s ease',
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        left: `${expectedPct}%`,
+                        top: -3,
+                        width: 2,
+                        height: 14,
+                        backgroundColor: 'text.secondary',
+                      }}
+                    />
+                  </Box>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+                      now: <Box component="span" sx={{ color: 'primary.main', fontWeight: 600 }}>{goal.current_one_rm} kg</Box>
+                    </Typography>
+                    <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+                      plan: {goal.expected_one_rm} kg
+                    </Typography>
+                    <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+                      target: {goal.target_one_rm} kg
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+
+        <Dialog open={createOpen} onClose={() => setCreateOpen(false)} fullWidth maxWidth="sm">
+          <DialogTitle sx={{ fontSize: 13, fontWeight: 600 }}>New goal</DialogTitle>
+          <DialogContent>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+              <ScrollablePicker
+                items={groupedExercises}
+                value={formExercise}
+                onChange={setFormExercise}
+                label="Exercise"
+                grouped
+                getGroupLabel={(g) => g.label}
+                searchEnabled
+                searchPlaceholder="Search exercises..."
+              />
+              {formExercise && currentOneRm !== null && (
+                <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                  {currentOneRm > 0
+                    ? <>Current estimated 1RM: <Box component="span" sx={{ color: 'primary.main', fontWeight: 600 }}>{Math.round(currentOneRm * 10) / 10} kg</Box></>
+                    : 'No logged sets yet for this exercise — log some first so a starting point can be estimated.'}
+                </Typography>
+              )}
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                <TextField
+                  label="Target 1RM (kg)"
+                  type="number"
+                  size="small"
+                  value={formTarget}
+                  onChange={(e) => setFormTarget(e.target.value)}
+                  inputProps={{ min: 0, step: 0.5, inputMode: 'decimal' }}
+                  sx={{ flex: 1 }}
+                />
+                <DatePicker
+                  label="Target date"
+                  value={formDate}
+                  onChange={setFormDate}
+                  disablePast
+                  slotProps={{ textField: { size: 'small', sx: { flex: 1 } } }}
+                />
+              </Box>
+              {rateLabel && (
+                <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                  Requires <Box component="span" sx={{ color: rateLabel.color, fontWeight: 600 }}>+{weeklyRate.toFixed(1)} kg/week</Box> — {rateLabel.text}
+                </Typography>
+              )}
+              {error && (
+                <Typography sx={{ fontSize: 12, color: 'error.main' }}>{error}</Typography>
+              )}
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setCreateOpen(false)} sx={{ fontSize: 13 }}>Cancel</Button>
+            <Button
+              onClick={handleCreate}
+              variant="contained"
+              disabled={saving || !formExercise || !formTarget || !formDate || !currentOneRm}
+              sx={{ fontSize: 13 }}
+            >
+              {saving ? 'Saving...' : 'Create goal'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+          <DialogTitle sx={{ fontSize: 13 }}>Delete goal</DialogTitle>
+          <DialogContent>
+            <Typography sx={{ fontSize: 13 }}>
+              Delete the {deleteTarget?.exercise_name} goal? Your logged sets are not affected.
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setDeleteTarget(null)} sx={{ fontSize: 13 }}>Cancel</Button>
+            <Button onClick={handleDelete} color="error" variant="contained" sx={{ fontSize: 13 }}>Delete</Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </LocalizationProvider>
+  );
+};
+
+export default Goals;

--- a/frontend/src/components/Menu.js
+++ b/frontend/src/components/Menu.js
@@ -14,6 +14,7 @@ import {
   LibraryBooks as LibraryIcon,
   Logout as LogoutIcon,
   Person as PersonIcon,
+  Flag as GoalIcon,
 } from '@mui/icons-material';
 
 const Menu = ({ user, onNavigate, onLogout }) => {
@@ -28,6 +29,11 @@ const Menu = ({ user, onNavigate, onLogout }) => {
       text: user?.username || 'User',
       disabled: true,
       onClick: null,
+    },
+    {
+      icon: <GoalIcon />,
+      text: 'Goals',
+      onClick: () => onNavigate('/goals'),
     },
     {
       icon: <HistoryIcon />,

--- a/frontend/src/components/Performance.js
+++ b/frontend/src/components/Performance.js
@@ -1,13 +1,11 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
-  Card,
-  CardContent,
   Typography,
   Button,
   ButtonGroup,
-  CircularProgress,
   Alert,
+  Skeleton,
   Table,
   TableBody,
   TableCell,
@@ -24,7 +22,18 @@ import { format, parseISO, startOfISOWeek, subMonths, subYears } from 'date-fns'
 import { OPTIMAL_RANGES } from './WorkoutPlanner';
 import { API_BASE_URL } from '../App';
 
-// Utility functions
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const chartText = '#8b949e';
+const gridColor = 'rgba(255, 255, 255, 0.06)';
+const axisColor = 'rgba(255, 255, 255, 0.12)';
+const tooltipStyle = {
+  backgroundColor: '#1c242c',
+  borderColor: '#2a333d',
+  borderRadius: 8,
+  style: { color: '#e8edf2', fontSize: '12px' },
+};
+
 function calc1RM(weight, reps) {
   if (!weight || !reps) return 0;
   return weight / (1.0278 - 0.0278 * reps);
@@ -47,7 +56,7 @@ function loess(xs, ys, bandwidth = 0.08) {
   const n = xs.length;
   const bw = Math.max(2, Math.floor(bandwidth * n));
   const result = [];
-  
+
   for (let i = 0; i < n; i++) {
     const distances = xs.map(x => Math.abs(x - xs[i]));
     const idxs = distances
@@ -55,7 +64,7 @@ function loess(xs, ys, bandwidth = 0.08) {
       .sort((a, b) => a[0] - b[0])
       .slice(0, bw)
       .map(pair => pair[1]);
-    
+
     const xw = idxs.map(j => xs[j]);
     const yw = idxs.map(j => ys[j]);
     const xbar = xw.reduce((a, b) => a + b, 0) / bw;
@@ -69,6 +78,20 @@ function loess(xs, ys, bandwidth = 0.08) {
   return result;
 }
 
+const StatCard = ({ label, value, unit, accent }) => (
+  <Box sx={{ backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 3, p: 1.5 }}>
+    <Typography sx={{ fontSize: 10, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: '0.06em', mb: 0.5 }}>
+      {label}
+    </Typography>
+    <Typography sx={{ fontSize: 18, fontWeight: 700, color: accent || 'text.primary', lineHeight: 1.1 }}>
+      {value}
+      {unit && (
+        <Box component="span" sx={{ fontSize: 11, fontWeight: 500, color: 'text.secondary', ml: 0.5 }}>{unit}</Box>
+      )}
+    </Typography>
+  </Box>
+);
+
 const Performance = () => {
   const [exercises, setExercises] = useState([]);
   const [selectedExercise, setSelectedExercise] = useState('');
@@ -78,21 +101,18 @@ const Performance = () => {
   const [weeklySetsData, setWeeklySetsData] = useState([]);
   const [muscleGroup, setMuscleGroup] = useState('');
   const [timeRange, setTimeRange] = useState('all');
-  const sectionSx = {
-    borderBottom: '1px solid',
-    borderColor: 'divider',
-    borderRadius: 0,
-    boxShadow: 'none',
-    bgcolor: 'transparent',
-  };
+  const [goals, setGoals] = useState([]);
+  const [showAllSets, setShowAllSets] = useState(false);
 
-  // Fetch exercises on component mount
   useEffect(() => {
     fetchExercises();
+    axios.get(`${API_BASE_URL}/api/goals`)
+      .then(res => setGoals(Array.isArray(res.data) ? res.data : []))
+      .catch(() => setGoals([]));
   }, []);
 
-  // Fetch performance data when exercise selection changes
   useEffect(() => {
+    setShowAllSets(false);
     if (selectedExercise) {
       fetchPerformanceData(selectedExercise);
     } else {
@@ -100,7 +120,6 @@ const Performance = () => {
     }
   }, [selectedExercise]);
 
-  // Update muscle group when exercise changes
   useEffect(() => {
     if (selectedExercise && exercises.length > 0) {
       const ex = exercises.find(e => e.id === selectedExercise);
@@ -120,7 +139,6 @@ const Performance = () => {
     }
   }, [muscleGroup]);
 
-  // Fetch weekly sets data when muscle group changes
   useEffect(() => {
     if (muscleGroup) {
       fetchWeeklySetsData();
@@ -158,6 +176,11 @@ const Performance = () => {
     }
   };
 
+  const activeGoal = useMemo(() => {
+    if (!selectedExercise || !goals.length) return null;
+    return goals.find(g => g.exercise_id === selectedExercise) || null;
+  }, [goals, selectedExercise]);
+
   const rangeStart = useMemo(() => {
     if (timeRange === '3m') return subMonths(new Date(), 3);
     if (timeRange === '6m') return subMonths(new Date(), 6);
@@ -182,6 +205,32 @@ const Performance = () => {
     return getDailyMax1RM(points);
   }, [filteredSets]);
 
+  // Headline stats use the full (unfiltered) history
+  const headline = useMemo(() => {
+    if (!allSets.length) return null;
+    const dailyMax = getDailyMax1RM(allSets.map(s => ({ date: s.date, one_rm: calc1RM(s.weight, s.reps) })));
+    if (!dailyMax.length) return null;
+    const xs = dailyMax.map(p => new Date(p.date).getTime());
+    const ys = dailyMax.map(p => p.one_rm);
+    let current = ys[ys.length - 1];
+    let line = null;
+    if (xs.length > 2) {
+      line = loess(xs, ys, 0.08);
+      current = line[line.length - 1][1];
+    }
+    const best = Math.max(...ys);
+    let change30 = null;
+    if (line && xs[xs.length - 1] - xs[0] >= 21 * MS_PER_DAY) {
+      const cutoff = xs[xs.length - 1] - 30 * MS_PER_DAY;
+      let idx = 0;
+      for (let i = 0; i < line.length; i++) {
+        if (line[i][0] <= cutoff) idx = i;
+      }
+      change30 = current - line[idx][1];
+    }
+    return { current, best, change30 };
+  }, [allSets]);
+
   const weeklySetsFiltered = useMemo(() => {
     if (!weeklySetsData.length || !rangeStart) return weeklySetsData;
     return weeklySetsData.filter((row) => {
@@ -197,15 +246,13 @@ const Performance = () => {
     });
   }, [weeklySetsData, rangeStart]);
 
-  // Memoize expensive calculations
-  const scatterData = useMemo(() => 
+  const scatterData = useMemo(() =>
     filteredDailyMaxPoints.map(pt => [
       new Date(pt.date).getTime(),
       pt.one_rm
     ]), [filteredDailyMaxPoints]
   );
 
-  // Calculate LOESS smoothed line (memoized)
   const loessLine = useMemo(() => {
     if (scatterData.length > 2) {
       const xs = scatterData.map(d => d[0]);
@@ -215,95 +262,104 @@ const Performance = () => {
     return [];
   }, [scatterData]);
 
+  const goalSeries = useMemo(() => {
+    if (!activeGoal) return null;
+    return [
+      [new Date(activeGoal.start_date).getTime(), activeGoal.start_one_rm],
+      [new Date(activeGoal.target_date).getTime(), activeGoal.target_one_rm],
+    ];
+  }, [activeGoal]);
+
   const chartOptions = {
     chart: {
       type: 'scatter',
       zoomType: 'xy',
       backgroundColor: 'transparent',
       style: { fontFamily: 'inherit' },
+      height: 320,
+      spacing: [8, 4, 8, 4],
     },
     title: { text: '' },
     xAxis: {
       type: 'datetime',
       title: { text: null },
-      labels: { 
-        style: { 
-          fontSize: '14px',
-          color: '#ffffff'
-        } 
-      },
+      lineColor: axisColor,
+      tickColor: 'transparent',
+      gridLineWidth: 0,
+      labels: { style: { fontSize: '11px', color: chartText } },
     },
     yAxis: {
-      title: { text: '1RM (kg)' },
-      min: 0,
-      labels: { 
-        style: { 
-          fontSize: '14px',
-          color: '#ffffff'
-        } 
+      title: { text: null },
+      gridLineColor: gridColor,
+      labels: {
+        format: '{value} kg',
+        style: { fontSize: '11px', color: chartText },
       },
     },
     legend: { enabled: false },
     tooltip: {
+      ...tooltipStyle,
       formatter: function () {
-        return `<b>${format(parseISO(new Date(this.x).toISOString()), 'MMM d, yyyy')}</b><br/>1RM: <b>${this.y.toFixed(1)} kg</b>`;
+        return `<b>${format(new Date(this.x), 'MMM d, yyyy')}</b><br/>1RM: <b>${this.y.toFixed(1)} kg</b>`;
       },
-      style: { fontSize: '15px' },
     },
     plotOptions: {
       scatter: {
         marker: {
-          radius: 4,
-          fillColor: '#00d4aa',
-          lineColor: '#ffffff',
-          lineWidth: 1,
+          radius: 3.5,
+          fillColor: 'rgba(0, 212, 170, 0.85)',
+          lineWidth: 0,
         },
-        states: {
-          hover: {
-            enabled: true,
-            lineColor: '#00d4aa',
-          },
-        },
+        states: { hover: { enabled: true } },
       },
     },
     series: [
       {
-        name: 'Daily Max 1RM',
+        name: 'Daily max 1RM',
         data: scatterData,
         type: 'scatter',
       },
       {
-        name: 'LOESS Smoothed',
+        name: 'Trend',
         data: loessLine,
-        type: 'line',
+        type: 'area',
         color: '#ff6b35',
-        lineWidth: 4,
+        lineWidth: 3,
+        fillColor: {
+          linearGradient: { x1: 0, y1: 0, x2: 0, y2: 1 },
+          stops: [
+            [0, 'rgba(255, 107, 53, 0.16)'],
+            [1, 'rgba(255, 107, 53, 0)'],
+          ],
+        },
         marker: { enabled: false },
         enableMouseTracking: false,
-        tooltip: { enabled: false },
       },
+      ...(goalSeries ? [{
+        name: 'Goal',
+        data: goalSeries,
+        type: 'line',
+        color: chartText,
+        lineWidth: 2,
+        dashStyle: 'Dash',
+        marker: { enabled: true, radius: 3, symbol: 'circle', fillColor: 'transparent', lineColor: chartText, lineWidth: 2 },
+        tooltip: {
+          pointFormatter: function () {
+            return `Goal: <b>${this.y.toFixed(1)} kg</b>`;
+          },
+        },
+      }] : []),
     ],
     credits: { enabled: false },
-    responsive: {
-      rules: [{
-        condition: { maxWidth: 600 },
-        chartOptions: {
-          chart: { height: 350 },
-          xAxis: { labels: { style: { fontSize: '11px', color: '#ffffff' } } },
-          yAxis: { labels: { style: { fontSize: '11px', color: '#ffffff' } } },
-        },
-      }],
-    },
   };
 
-  // Weekly Sets Chart configuration
   let weeklySetsChartOptions = null;
   if (weeklySetsFiltered.length > 0 && muscleGroup) {
     const weeks = weeklySetsFiltered.map(row => row.week);
     const sets = weeklySetsFiltered.map(row => parseInt(row.total_sets, 10));
     const optimal = OPTIMAL_RANGES[muscleGroup];
     let minOpt = 0, maxOpt = 0;
-    
+
     if (optimal && optimal.sets) {
       const match = optimal.sets.match(/(\d+)[^\d]+(\d+)/);
       if (match) {
@@ -311,61 +367,48 @@ const Performance = () => {
         maxOpt = parseInt(match[2], 10);
       }
     }
-    
+
     weeklySetsChartOptions = {
-      chart: { 
-        type: 'column', 
-        backgroundColor: 'transparent', 
-        style: { fontFamily: 'inherit' } 
+      chart: {
+        type: 'column',
+        backgroundColor: 'transparent',
+        style: { fontFamily: 'inherit' },
+        height: 260,
+        spacing: [8, 4, 8, 4],
       },
       title: { text: '' },
-      xAxis: { 
-        categories: weeks, 
-        title: { text: 'Week' }, 
-        labels: { 
-          style: { 
-            fontSize: '14px',
-            color: '#ffffff'
-          } 
-        } 
+      xAxis: {
+        categories: weeks,
+        title: { text: null },
+        lineColor: axisColor,
+        tickColor: 'transparent',
+        labels: { style: { fontSize: '10px', color: chartText } },
       },
       yAxis: {
         min: 0,
-        title: { text: 'Sets per Week' },
+        title: { text: null },
+        gridLineColor: gridColor,
         plotBands: minOpt && maxOpt ? [{
           from: minOpt,
           to: maxOpt,
-          color: 'rgba(0, 212, 170, 0.15)',
-          label: { 
-            text: `Optimal: ${minOpt}-${maxOpt}`, 
-            style: { color: '#00d4aa', fontWeight: 600 } 
+          color: 'rgba(0, 212, 170, 0.08)',
+          label: {
+            text: `Optimal ${minOpt}–${maxOpt}`,
+            style: { color: '#5DCAA5', fontSize: '10px', fontWeight: '500' },
           }
         }] : [],
-        labels: { 
-          style: { 
-            fontSize: '14px',
-            color: '#ffffff'
-          } 
-        },
+        labels: { style: { fontSize: '11px', color: chartText } },
       },
-      tooltip: { valueSuffix: ' sets', style: { fontSize: '15px' } },
-      series: [{ name: muscleGroup, data: sets, color: '#00d4aa' }],
+      tooltip: { ...tooltipStyle, valueSuffix: ' sets' },
+      plotOptions: {
+        column: { borderWidth: 0, borderRadius: 3 },
+      },
+      series: [{ name: muscleGroup, data: sets, color: 'rgba(0, 212, 170, 0.8)' }],
       credits: { enabled: false },
       legend: { enabled: false },
-      responsive: { 
-        rules: [{ 
-          condition: { maxWidth: 600 }, 
-          chartOptions: { 
-            chart: { height: 300 }, 
-            xAxis: { labels: { style: { fontSize: '11px', color: '#ffffff' } } }, 
-            yAxis: { labels: { style: { fontSize: '11px', color: '#ffffff' } } } 
-          } 
-        }] 
-      },
     };
   }
 
-  // Group exercises by muscle group for the dropdown
   const groupedExercises = exercises.reduce((groups, ex) => {
     if (!groups[ex.muscle_group]) groups[ex.muscle_group] = [];
     groups[ex.muscle_group].push(ex);
@@ -377,118 +420,147 @@ const Performance = () => {
     items,
   }));
 
-  return (
-    <Box maxWidth={600} mx="auto" mt={2} px={{ xs: 1.5, sm: 0 }} sx={{ '& .MuiTypography-root': { fontSize: 13 } }}>
-      <Typography variant="h4" fontWeight={700} gutterBottom align="center" sx={{ fontSize: 13 }}>
-        Performance
-      </Typography>
-      <Card sx={{ ...sectionSx, mb: 2 }}>
-        <CardContent>
-          <Box sx={{ mb: 2 }}>
-            <ScrollablePicker
-              items={exerciseGroups}
-              value={selectedExercise}
-              onChange={setSelectedExercise}
-              label="Select Exercise"
-              grouped
-              getGroupLabel={(g) => g.label}
-              searchEnabled
-              searchPlaceholder="Search exercises..."
-            />
-          </Box>
-          
-          <Box sx={{ mb: 2 }}>
-            <ButtonGroup size="small" variant="outlined" fullWidth sx={{ width: '100%' }}>
-              <Button
-                variant={timeRange === 'all' ? 'contained' : 'outlined'}
-                onClick={() => setTimeRange('all')}
-                sx={{ flex: 1 }}
-              >
-                All
-              </Button>
-              <Button
-                variant={timeRange === '1y' ? 'contained' : 'outlined'}
-                onClick={() => setTimeRange('1y')}
-                sx={{ flex: 1 }}
-              >
-                1 year
-              </Button>
-              <Button
-                variant={timeRange === '6m' ? 'contained' : 'outlined'}
-                onClick={() => setTimeRange('6m')}
-                sx={{ flex: 1 }}
-              >
-                6 months
-              </Button>
-              <Button
-                variant={timeRange === '3m' ? 'contained' : 'outlined'}
-                onClick={() => setTimeRange('3m')}
-                sx={{ flex: 1 }}
-              >
-                3 months
-              </Button>
-            </ButtonGroup>
-          </Box>
+  const sortedSets = useMemo(() =>
+    filteredSets.slice().sort((a, b) => b.date.localeCompare(a.date)),
+    [filteredSets]
+  );
+  const visibleSets = showAllSets ? sortedSets : sortedSets.slice(0, 10);
 
-          {loading ? (
-            <Box display="flex" justifyContent="center" alignItems="center" minHeight={200}>
-              <CircularProgress />
+  const sectionTitleSx = {
+    fontWeight: 700,
+    fontSize: 11,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    color: 'text.secondary',
+    mb: 1,
+  };
+
+  return (
+    <Box maxWidth={600} mx="auto" mt={2} px={{ xs: 1.5, sm: 0 }}>
+      <Box sx={{ mb: 2 }}>
+        <ScrollablePicker
+          items={exerciseGroups}
+          value={selectedExercise}
+          onChange={setSelectedExercise}
+          label="Select Exercise"
+          grouped
+          getGroupLabel={(g) => g.label}
+          searchEnabled
+          searchPlaceholder="Search exercises..."
+        />
+      </Box>
+
+      <Box sx={{ mb: 2 }}>
+        <ButtonGroup size="small" variant="outlined" fullWidth sx={{ width: '100%' }}>
+          {[['all', 'All'], ['1y', '1 year'], ['6m', '6 months'], ['3m', '3 months']].map(([key, label]) => (
+            <Button
+              key={key}
+              variant={timeRange === key ? 'contained' : 'outlined'}
+              onClick={() => setTimeRange(key)}
+              sx={{ flex: 1, fontSize: 12 }}
+            >
+              {label}
+            </Button>
+          ))}
+        </ButtonGroup>
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1 }}>
+            <Skeleton variant="rounded" height={64} />
+            <Skeleton variant="rounded" height={64} />
+            <Skeleton variant="rounded" height={64} />
+          </Box>
+          <Skeleton variant="rounded" height={300} />
+        </Box>
+      ) : error ? (
+        <Alert severity="error">{error}</Alert>
+      ) : !selectedExercise ? (
+        <Typography color="text.secondary" align="center" py={6} sx={{ fontSize: 13 }}>
+          Pick an exercise to see your progress
+        </Typography>
+      ) : filteredDailyMaxPoints.length === 0 ? (
+        <Typography color="text.secondary" align="center" py={6} sx={{ fontSize: 13 }}>
+          No data for this exercise
+        </Typography>
+      ) : (
+        <>
+          {headline && (
+            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1, mb: 2 }}>
+              <StatCard label="Est. 1RM" value={headline.current.toFixed(1)} unit="kg" accent="primary.main" />
+              <StatCard label="All-time best" value={headline.best.toFixed(1)} unit="kg" />
+              <StatCard
+                label="30-day change"
+                value={headline.change30 == null ? '—' : `${headline.change30 >= 0 ? '+' : ''}${headline.change30.toFixed(1)}`}
+                unit={headline.change30 == null ? '' : 'kg'}
+                accent={headline.change30 == null ? 'text.secondary' : headline.change30 >= 0 ? 'primary.main' : '#F09595'}
+              />
             </Box>
-          ) : error ? (
-            <Alert severity="error">{error}</Alert>
-          ) : filteredDailyMaxPoints.length === 0 ? (
-            <Typography color="text.secondary" align="center" py={4} sx={{ fontSize: 13 }}>
-              No data for this exercise
-            </Typography>
-          ) : (
-            <>
-              <HighchartsReact highcharts={Highcharts} options={chartOptions} />
-              
-              {weeklySetsChartOptions && (
-                <Box mt={4}>
-                <Typography variant="h6" fontWeight={600} gutterBottom sx={{ fontSize: 13 }}>
-                  Weekly Sets for {muscleGroup}
-                </Typography>
-                  <HighchartsReact highcharts={Highcharts} options={weeklySetsChartOptions} />
-                </Box>
-              )}
-              
-              <Box mt={4}>
-                <Typography variant="h6" fontWeight={600} gutterBottom sx={{ fontSize: 13 }}>
-                  All Logged Sets
-                </Typography>
-                <TableContainer component={Paper} sx={{ boxShadow: 'none', bgcolor: 'transparent', '& .MuiTableCell-root': { fontSize: 13 } }}>
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Date</TableCell>
-                        <TableCell align="right">Weight (kg)</TableCell>
-                        <TableCell align="right">Reps</TableCell>
-                        <TableCell align="right">1RM (kg)</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {filteredSets
-                        .slice()
-                        .sort((a, b) => b.date.localeCompare(a.date))
-                        .map((row, idx) => (
-                          <TableRow key={`${row.date}-${row.set_number}-${idx}`}>
-                            <TableCell>{format(parseISO(row.date), 'yyyy-MM-dd')}</TableCell>
-                            <TableCell align="right">{row.weight}</TableCell>
-                            <TableCell align="right">{row.reps}</TableCell>
-                            <TableCell align="right">{calc1RM(row.weight, row.reps).toFixed(1)}</TableCell>
-                          </TableRow>
-                        ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              </Box>
-            </>
           )}
-        </CardContent>
-      </Card>
+
+          {activeGoal && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+              <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: activeGoal.on_track ? 'primary.main' : '#FAC775' }} />
+              <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                Goal: {activeGoal.target_one_rm} kg by {format(parseISO(activeGoal.target_date), 'd MMM yyyy')} —{' '}
+                {activeGoal.achieved ? 'achieved' : activeGoal.on_track ? 'on track' : `behind plan (${activeGoal.expected_one_rm} kg expected)`}
+              </Typography>
+            </Box>
+          )}
+
+          <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+
+          {weeklySetsChartOptions && (
+            <Box mt={3}>
+              <Typography sx={sectionTitleSx}>
+                Weekly sets — {muscleGroup}
+              </Typography>
+              <HighchartsReact highcharts={Highcharts} options={weeklySetsChartOptions} />
+            </Box>
+          )}
+
+          <Box mt={3}>
+            <Typography sx={sectionTitleSx}>
+              Logged sets
+            </Typography>
+            <TableContainer component={Paper} sx={{ boxShadow: 'none', bgcolor: 'transparent', '& .MuiTableCell-root': { fontSize: 13, borderColor: 'divider' } }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ color: 'text.secondary' }}>Date</TableCell>
+                    <TableCell align="right" sx={{ color: 'text.secondary' }}>Weight</TableCell>
+                    <TableCell align="right" sx={{ color: 'text.secondary' }}>Reps</TableCell>
+                    <TableCell align="right" sx={{ color: 'text.secondary' }}>1RM</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {visibleSets.map((row, idx) => (
+                    <TableRow key={`${row.date}-${row.set_number}-${idx}`}>
+                      <TableCell>{format(parseISO(row.date), 'd MMM yy')}</TableCell>
+                      <TableCell align="right">{row.weight} kg</TableCell>
+                      <TableCell align="right">{row.reps}</TableCell>
+                      <TableCell align="right">{calc1RM(row.weight, row.reps).toFixed(1)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            {sortedSets.length > 10 && (
+              <Button
+                size="small"
+                onClick={() => setShowAllSets(v => !v)}
+                sx={{ mt: 1, fontSize: 12, color: 'text.secondary' }}
+                fullWidth
+              >
+                {showAllSets ? 'Show less' : `Show all ${sortedSets.length} sets`}
+              </Button>
+            )}
+          </Box>
+        </>
+      )}
     </Box>
   );
 };
 
-export default Performance; 
+export default Performance;

--- a/frontend/src/components/WorkoutEntry.js
+++ b/frontend/src/components/WorkoutEntry.js
@@ -45,6 +45,7 @@ const WorkoutEntry = ({ onStatusMessage }) => {
   const [showPlannedExercises, setShowPlannedExercises] = useState(true);
   const [saveConfirmOpen, setSaveConfirmOpen] = useState(false);
   const [oneRmRanges, setOneRmRanges] = useState({});
+  const [goals, setGoals] = useState([]);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -314,6 +315,7 @@ const WorkoutEntry = ({ onStatusMessage }) => {
       try {
         await fetchExercises();
         await fetchUserPlan();
+        await fetchGoals();
       } catch (error) {
         console.error('Error initializing WorkoutEntry component:', error);
       } finally {
@@ -357,6 +359,20 @@ const WorkoutEntry = ({ onStatusMessage }) => {
       setUserPlan(null);
     }
   };
+
+  const fetchGoals = async () => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/api/goals`);
+      setGoals(Array.isArray(response.data) ? response.data : []);
+    } catch (error) {
+      setGoals([]);
+    }
+  };
+
+  const activeGoal = useMemo(() => {
+    if (!selectedExercise || !goals.length) return null;
+    return goals.find((g) => g.exercise_id === parseInt(selectedExercise, 10)) || null;
+  }, [goals, selectedExercise]);
 
   const fetchRecentData = useCallback(async () => {
     if (!selectedExercise) {
@@ -862,7 +878,21 @@ const WorkoutEntry = ({ onStatusMessage }) => {
                     ) : null;
                   })()}
                 </Box>
-                
+
+                {/* Active goal: this week's target */}
+                {activeGoal && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: sectionGap, pb: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
+                    <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: activeGoal.on_track ? 'primary.main' : '#FAC775', flexShrink: 0 }} />
+                    <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                      Goal {activeGoal.target_one_rm} kg: this week{' '}
+                      <Box component="span" sx={{ color: 'primary.main', fontWeight: 600 }}>
+                        {roundToNearest2_5(activeGoal.expected_one_rm * (1.0278 - 0.0278 * 5))} kg × 5
+                      </Box>{' '}
+                      (1RM {activeGoal.expected_one_rm}) · {activeGoal.achieved ? 'achieved' : activeGoal.on_track ? 'on track' : 'behind plan'}
+                    </Typography>
+                  </Box>
+                )}
+
                 {/* Weight Calculator Slider */}
                 {selectedExercise && estimatedOneRepMax > 0 && (
                   <Box sx={{ mb: sectionGap }}>

--- a/frontend/src/components/WorkoutHistory.js
+++ b/frontend/src/components/WorkoutHistory.js
@@ -1,56 +1,226 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Box,
   Typography,
-  CircularProgress,
   Alert,
   IconButton,
-  Chip,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
   Button,
+  Collapse,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
+  Skeleton,
 } from '@mui/material';
 import {
-  ExpandMore as ExpandMoreIcon,
   Delete as DeleteIcon,
-  Visibility as ViewIcon,
+  ExpandMore as ExpandMoreIcon,
   Search as SearchIcon,
 } from '@mui/icons-material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { format, parseISO } from 'date-fns';
+import {
+  format,
+  parseISO,
+  isToday,
+  isYesterday,
+  differenceInCalendarDays,
+  startOfISOWeek,
+  addDays,
+  subWeeks,
+} from 'date-fns';
 import axios from 'axios';
 import { API_BASE_URL } from '../App';
+
+const DOT_PALETTE = [
+  '#5DCAA5', '#F0997B', '#85B7EB', '#ED93B1', '#FAC775',
+  '#AFA9EC', '#97C459', '#F09595', '#9FE1CB', '#B4B2A9',
+];
+
+const muscleColor = (group) => {
+  if (!group) return '#888780';
+  let hash = 0;
+  for (let i = 0; i < group.length; i++) {
+    hash = (hash * 31 + group.charCodeAt(i)) >>> 0;
+  }
+  return DOT_PALETTE[hash % DOT_PALETTE.length];
+};
+
+const relativeDate = (dateStr) => {
+  const date = parseISO(dateStr);
+  if (isToday(date)) return 'Today';
+  if (isYesterday(date)) return 'Yesterday';
+  if (differenceInCalendarDays(new Date(), date) < 7) return format(date, 'EEEE');
+  if (date.getFullYear() === new Date().getFullYear()) return format(date, 'EEE d MMM');
+  return format(date, 'd MMM yyyy');
+};
+
+const HEATMAP_WEEKS = 20;
+
+const Heatmap = ({ workouts }) => {
+  const { weeks, maxSets } = useMemo(() => {
+    const setsByDate = {};
+    workouts.forEach(w => {
+      const key = w.date.slice(0, 10);
+      setsByDate[key] = (setsByDate[key] || 0) + (w.sets?.length || 0);
+    });
+    const start = startOfISOWeek(subWeeks(new Date(), HEATMAP_WEEKS - 1));
+    const weeks = [];
+    let maxSets = 0;
+    for (let wk = 0; wk < HEATMAP_WEEKS; wk++) {
+      const days = [];
+      for (let d = 0; d < 7; d++) {
+        const day = addDays(start, wk * 7 + d);
+        const key = format(day, 'yyyy-MM-dd');
+        const count = setsByDate[key] || 0;
+        maxSets = Math.max(maxSets, count);
+        days.push({ key, count, future: day > new Date() });
+      }
+      weeks.push(days);
+    }
+    return { weeks, maxSets };
+  }, [workouts]);
+
+  const cellColor = (cell) => {
+    if (cell.future) return 'transparent';
+    if (cell.count === 0) return 'rgba(255, 255, 255, 0.05)';
+    const intensity = Math.min(1, cell.count / Math.max(maxSets * 0.75, 1));
+    return `rgba(0, 212, 170, ${0.25 + intensity * 0.65})`;
+  };
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Box sx={{ display: 'flex', gap: '3px', justifyContent: 'space-between' }}>
+        {weeks.map((days, wi) => (
+          <Box key={wi} sx={{ display: 'flex', flexDirection: 'column', gap: '3px', flex: 1 }}>
+            {days.map((cell) => (
+              <Box
+                key={cell.key}
+                title={`${cell.key}: ${cell.count} sets`}
+                sx={{
+                  width: '100%',
+                  aspectRatio: '1',
+                  borderRadius: '2px',
+                  backgroundColor: cellColor(cell),
+                }}
+              />
+            ))}
+          </Box>
+        ))}
+      </Box>
+      <Typography sx={{ fontSize: 10, color: 'text.secondary', mt: 0.75 }}>
+        Last {HEATMAP_WEEKS} weeks — darker means more sets
+      </Typography>
+    </Box>
+  );
+};
+
+const WorkoutCard = ({ workout, onDelete }) => {
+  const [open, setOpen] = useState(false);
+  const sets = useMemo(
+    () => (Array.isArray(workout.sets) ? workout.sets : []),
+    [workout.sets]
+  );
+  const volume = sets.reduce((sum, s) => sum + s.weight * s.reps, 0);
+  const groups = [...new Set(sets.map(s => s.muscle_group).filter(Boolean))];
+
+  const byExercise = useMemo(() => {
+    const acc = {};
+    sets.forEach(s => {
+      if (!acc[s.exercise_name]) acc[s.exercise_name] = [];
+      acc[s.exercise_name].push(s);
+    });
+    return acc;
+  }, [sets]);
+
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 3,
+        backgroundColor: 'background.paper',
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        onClick={() => setOpen(o => !o)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 1.75,
+          py: 1.25,
+          cursor: 'pointer',
+          '&:active': { backgroundColor: 'rgba(255,255,255,0.03)' },
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontSize: 13, fontWeight: 600, color: 'text.primary' }}>
+            {relativeDate(workout.date)}
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.25 }}>
+            <Box sx={{ display: 'flex', gap: 0.5 }}>
+              {groups.slice(0, 5).map(g => (
+                <Box key={g} title={g} sx={{ width: 7, height: 7, borderRadius: '50%', backgroundColor: muscleColor(g) }} />
+              ))}
+            </Box>
+            <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+              {sets.length} sets · {Math.round(volume).toLocaleString()} kg
+            </Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton
+            size="small"
+            color="error"
+            onClick={(e) => { e.stopPropagation(); onDelete(workout.id); }}
+            sx={{ p: 0.5, opacity: 0.7 }}
+          >
+            <DeleteIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+          <ExpandMoreIcon
+            sx={{
+              fontSize: 20,
+              color: 'text.secondary',
+              transform: open ? 'rotate(180deg)' : 'none',
+              transition: 'transform 0.2s ease',
+            }}
+          />
+        </Box>
+      </Box>
+      <Collapse in={open} timeout={200} unmountOnExit>
+        <Box sx={{ px: 1.75, pb: 1.5, borderTop: '1px solid', borderColor: 'divider', pt: 1 }}>
+          {Object.entries(byExercise).map(([name, exSets]) => (
+            <Box key={name} sx={{ mb: 1 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: muscleColor(exSets[0].muscle_group) }} />
+                <Typography sx={{ fontSize: 12.5, fontWeight: 600 }}>{name}</Typography>
+              </Box>
+              <Typography sx={{ fontSize: 12, color: 'text.secondary', ml: 1.6 }}>
+                {exSets.map(s => `${s.weight}×${s.reps}`).join('  ·  ')}
+              </Typography>
+            </Box>
+          ))}
+          {workout.notes && (
+            <Typography sx={{ fontSize: 11, color: 'text.secondary', fontStyle: 'italic', mt: 0.5 }}>
+              {workout.notes}
+            </Typography>
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
 
 const WorkoutHistory = () => {
   const [workouts, setWorkouts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [selectedWorkout, setSelectedWorkout] = useState(null);
-  const [viewDialogOpen, setViewDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [workoutToDelete, setWorkoutToDelete] = useState(null);
   const [searchDate, setSearchDate] = useState(null);
-  const sectionSx = {
-    borderBottom: '1px solid',
-    borderColor: 'divider',
-    borderRadius: 0,
-    boxShadow: 'none',
-    bgcolor: 'transparent',
-  };
 
   useEffect(() => {
     fetchWorkouts();
@@ -60,10 +230,8 @@ const WorkoutHistory = () => {
     try {
       setLoading(true);
       setError('');
-      
       const params = date ? { date: format(date, 'yyyy-MM-dd') } : {};
       const response = await axios.get(`${API_BASE_URL}/api/workouts`, { params });
-      // Ensure workouts is always an array
       setWorkouts(Array.isArray(response.data) ? response.data : []);
     } catch (err) {
       console.error('Error fetching workouts:', err);
@@ -76,242 +244,111 @@ const WorkoutHistory = () => {
     }
   };
 
-  const handleViewWorkout = async (workoutId) => {
-    try {
-      const response = await axios.get(`${API_BASE_URL}/api/workouts/${workoutId}`);
-      setSelectedWorkout(response.data);
-      setViewDialogOpen(true);
-    } catch (err) {
-      console.error('Error fetching workout details:', err);
-      setError('Failed to load workout details');
-    }
-  };
-
   const handleDeleteWorkout = async () => {
     if (!workoutToDelete) return;
-
     try {
       await axios.delete(`${API_BASE_URL}/api/workouts/${workoutToDelete}`);
-      setWorkouts(workouts.filter(w => w.id !== workoutToDelete));
-      setDeleteDialogOpen(false);
-      setWorkoutToDelete(null);
+      setWorkouts(ws => ws.filter(w => w.id !== workoutToDelete));
     } catch (err) {
       console.error('Error deleting workout:', err);
       setError('Failed to delete workout');
+    } finally {
+      setDeleteDialogOpen(false);
+      setWorkoutToDelete(null);
     }
   };
 
-  const handleSearch = () => {
-    fetchWorkouts(searchDate);
+  const requestDelete = (id) => {
+    setWorkoutToDelete(id);
+    setDeleteDialogOpen(true);
   };
 
-  const handleClearSearch = () => {
-    setSearchDate(null);
-    fetchWorkouts();
-  };
-
-  const getMuscleGroupColor = (muscleGroup) => {
-    const colors = {
-      chest: '#ff6b6b',
-      back: '#4ecdc4',
-      legs: '#45b7d1',
-      shoulders: '#96ceb4',
-      arms: '#feca57',
-      core: '#ff9ff3',
-    };
-    return colors[muscleGroup] || '#95a5a6';
-  };
-
-  const calculateWorkoutVolume = (sets) => {
-    if (!Array.isArray(sets)) return 0;
-    return sets.reduce((total, set) => total + (set.weight * set.reps), 0);
-  };
-
-  const getMuscleGroups = (sets) => {
-    if (!Array.isArray(sets)) return '';
-    const groups = [...new Set(sets.map(set => set.muscle_group))];
-    return groups.join(', ');
-  };
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
-  }
+  const monthGroups = useMemo(() => {
+    const groups = [];
+    let currentKey = null;
+    workouts.forEach(w => {
+      const key = format(parseISO(w.date), 'MMMM yyyy');
+      if (key !== currentKey) {
+        groups.push({ label: key, workouts: [] });
+        currentKey = key;
+      }
+      groups[groups.length - 1].workouts.push(w);
+    });
+    return groups;
+  }, [workouts]);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{ maxWidth: 520, mx: 'auto', mt: 2, px: { xs: 1.5, sm: 0 }, '& .MuiTypography-root': { fontSize: 13 } }}>
-        <Typography variant="h4" fontWeight={700} sx={{ mb: 1, fontSize: 13 }}>
-          Workout History
+      <Box sx={{ maxWidth: 520, mx: 'auto', mt: 2, px: { xs: 1.5, sm: 0 } }}>
+        <Typography sx={{ fontWeight: 700, fontSize: 13, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'text.secondary', mb: 1.5 }}>
+          History
         </Typography>
 
         {error && (
-          <Alert severity="error" sx={{ mb: 1 }} action={<Button color="inherit" size="small" onClick={() => fetchWorkouts(searchDate)}>Retry</Button>}>
+          <Alert severity="error" sx={{ mb: 1.5 }} action={<Button color="inherit" size="small" onClick={() => fetchWorkouts(searchDate)}>Retry</Button>}>
             {error}
           </Alert>
         )}
 
-        {/* Search Section */}
-        <Box sx={{ ...sectionSx, py: 1, mb: 1 }}>
-          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 1, alignItems: { sm: 'center' } }}>
-            <DatePicker
-              label="Search by Date"
-              value={searchDate}
-              onChange={setSearchDate}
-              slotProps={{ textField: { size: 'small', sx: { '& .MuiInputBase-root': { fontSize: 13 } } } }}
-            />
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button variant="contained" size="small" startIcon={<SearchIcon />} onClick={handleSearch} disabled={!searchDate} sx={{ fontSize: 13 }}>
-                Search
-              </Button>
-              <Button variant="outlined" size="small" onClick={handleClearSearch} sx={{ fontSize: 13 }}>
-                Clear
-              </Button>
-            </Box>
-          </Box>
-        </Box>
-
-        {/* Workouts List */}
-        {workouts.length === 0 ? (
-          <Box sx={{ ...sectionSx, py: 3 }}>
-            <Typography color="text.secondary" align="center" sx={{ fontSize: 13 }}>
-              {searchDate ? 'No workouts found for the selected date' : 'No workouts recorded yet'}
-            </Typography>
+        {loading ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Skeleton variant="rounded" height={92} />
+            <Skeleton variant="rounded" height={56} />
+            <Skeleton variant="rounded" height={56} />
+            <Skeleton variant="rounded" height={56} />
           </Box>
         ) : (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {Array.isArray(workouts) && workouts.map((workout) => (
-              <Box key={workout.id} sx={{ ...sectionSx, pb: 1 }}>
-                <Accordion sx={{ '&:before': { display: 'none' }, boxShadow: 'none', bgcolor: 'transparent' }}>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ fontSize: 20 }} />} sx={{ minHeight: 44, py: 0 }}>
-                    <Box display="flex" justifyContent="space-between" alignItems="center" width="100%" pr={1}>
-                      <Box>
-                        <Typography variant="subtitle1" fontWeight={600} sx={{ fontSize: 13, color: 'primary.main' }}>
-                          {format(parseISO(workout.date), 'MMM dd, yyyy')}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary" sx={{ fontSize: 11 }}>
-                          {workout.sets?.length || 0} sets • {getMuscleGroups(workout.sets || [])}
-                        </Typography>
-                      </Box>
-                      <Box display="flex" alignItems="center" gap={0.5}>
-                        <Typography variant="body2" color="text.secondary" sx={{ fontSize: 11 }}>
-                          {formatWeight(calculateWorkoutVolume(workout.sets || []))}
-                        </Typography>
-                        <IconButton size="small" onClick={(e) => { e.stopPropagation(); handleViewWorkout(workout.id); }} sx={{ p: 0.5 }}>
-                          <ViewIcon sx={{ fontSize: 18 }} />
-                        </IconButton>
-                        <IconButton size="small" color="error" onClick={(e) => { e.stopPropagation(); setWorkoutToDelete(workout.id); setDeleteDialogOpen(true); }} sx={{ p: 0.5 }}>
-                          <DeleteIcon sx={{ fontSize: 18 }} />
-                        </IconButton>
-                      </Box>
-                    </Box>
-                  </AccordionSummary>
-                  <AccordionDetails sx={{ pt: 0, px: 2, pb: 1 }}>
-                    <Box sx={{ display: 'table', width: '100%', borderCollapse: 'collapse' }}>
-                      {Array.isArray(workout.sets) && workout.sets.map((set, index) => (
-                        <Box key={set.id} sx={{ display: 'table-row' }}>
-                          <Box sx={{ display: 'table-cell', py: 0.75, px: 0, borderBottom: '1px solid', borderColor: 'divider', verticalAlign: 'middle' }}>
-                            <Typography variant="body2" sx={{ fontSize: 13 }}>
-                              {set.exercise_name}: {set.weight} kg × {set.reps} reps
-                            </Typography>
-                          </Box>
-                          <Box sx={{ display: 'table-cell', py: 0.75, px: 0, borderBottom: '1px solid', borderColor: 'divider', verticalAlign: 'middle', width: 80, textAlign: 'right' }}>
-                            <Chip label={set.muscle_group} size="small" sx={{ fontSize: 10, height: 20, backgroundColor: getMuscleGroupColor(set.muscle_group), color: 'white' }} />
-                          </Box>
-                        </Box>
-                      ))}
-                    </Box>
-                    {workout.notes && (
-                      <Typography variant="body2" color="text.secondary" sx={{ fontSize: 11, mt: 1 }}>
-                        <strong>Notes:</strong> {workout.notes}
-                      </Typography>
-                    )}
-                  </AccordionDetails>
-                </Accordion>
-              </Box>
-            ))}
-          </Box>
+          <>
+            {!searchDate && workouts.length > 0 && <Heatmap workouts={workouts} />}
+
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 2 }}>
+              <DatePicker
+                label="Jump to date"
+                value={searchDate}
+                onChange={setSearchDate}
+                slotProps={{ textField: { size: 'small', sx: { flex: 1, '& .MuiInputBase-root': { fontSize: 13 } } } }}
+              />
+              <IconButton size="small" onClick={() => fetchWorkouts(searchDate)} disabled={!searchDate} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+                <SearchIcon sx={{ fontSize: 18 }} />
+              </IconButton>
+              {searchDate && (
+                <Button size="small" onClick={() => { setSearchDate(null); fetchWorkouts(); }} sx={{ fontSize: 12 }}>
+                  Clear
+                </Button>
+              )}
+            </Box>
+
+            {workouts.length === 0 ? (
+              <Typography color="text.secondary" align="center" sx={{ fontSize: 13, py: 4 }}>
+                {searchDate ? 'No workouts on the selected date' : 'No workouts recorded yet'}
+              </Typography>
+            ) : (
+              monthGroups.map(group => (
+                <Box key={group.label} sx={{ mb: 2.5 }}>
+                  <Typography sx={{ fontSize: 11, fontWeight: 600, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: '0.05em', mb: 1 }}>
+                    {group.label}
+                  </Typography>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                    {group.workouts.map(w => (
+                      <WorkoutCard key={w.id} workout={w} onDelete={requestDelete} />
+                    ))}
+                  </Box>
+                </Box>
+              ))
+            )}
+          </>
         )}
 
-        {/* View Workout Dialog */}
-        <Dialog
-          open={viewDialogOpen}
-          onClose={() => setViewDialogOpen(false)}
-          maxWidth="md"
-          fullWidth
-        >
-          <DialogTitle sx={{ fontSize: 13 }}>
-            Workout Details - {selectedWorkout && format(parseISO(selectedWorkout.date), 'MMM dd, yyyy')}
-          </DialogTitle>
-          <DialogContent>
-            {selectedWorkout && (
-              <Box>
-                <TableContainer component={Paper} sx={{ boxShadow: 'none', bgcolor: 'transparent', '& .MuiTableCell-root': { fontSize: 13 } }}>
-                  <Table>
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Set</TableCell>
-                        <TableCell>Exercise</TableCell>
-                        <TableCell>Muscle Group</TableCell>
-                        <TableCell align="right">Weight</TableCell>
-                        <TableCell align="right">Reps</TableCell>
-                        <TableCell align="right">Volume</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {Array.isArray(selectedWorkout.sets) && selectedWorkout.sets.map((set, index) => (
-                        <TableRow key={set.id}>
-                          <TableCell>{index + 1}</TableCell>
-                          <TableCell>{set.exercise_name}</TableCell>
-                          <TableCell>
-                            <Chip
-                              label={set.muscle_group}
-                              size="small"
-                              sx={{
-                                backgroundColor: getMuscleGroupColor(set.muscle_group),
-                                color: 'white',
-                              }}
-                            />
-                          </TableCell>
-                          <TableCell align="right">{set.weight} kg</TableCell>
-                          <TableCell align="right">{set.reps}</TableCell>
-                          <TableCell align="right">{formatWeight(set.weight * set.reps)}</TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-                {selectedWorkout.notes && (
-                  <Box mt={2}>
-                    <Typography variant="h6" sx={{ fontSize: 13 }}>Notes:</Typography>
-                    <Typography variant="body1" sx={{ fontSize: 13 }}>{selectedWorkout.notes}</Typography>
-                  </Box>
-                )}
-              </Box>
-            )}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setViewDialogOpen(false)}>Close</Button>
-          </DialogActions>
-        </Dialog>
-
-        {/* Delete Confirmation Dialog */}
-        <Dialog
-          open={deleteDialogOpen}
-          onClose={() => setDeleteDialogOpen(false)}
-        >
-          <DialogTitle sx={{ fontSize: 13 }}>Delete Workout</DialogTitle>
+        <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
+          <DialogTitle sx={{ fontSize: 13 }}>Delete workout</DialogTitle>
           <DialogContent>
             <Typography sx={{ fontSize: 13 }}>
               Are you sure you want to delete this workout? This action cannot be undone.
             </Typography>
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
-            <Button onClick={handleDeleteWorkout} color="error" variant="contained">
+            <Button onClick={() => setDeleteDialogOpen(false)} sx={{ fontSize: 13 }}>Cancel</Button>
+            <Button onClick={handleDeleteWorkout} color="error" variant="contained" sx={{ fontSize: 13 }}>
               Delete
             </Button>
           </DialogActions>
@@ -321,6 +358,4 @@ const WorkoutHistory = () => {
   );
 };
 
-const formatWeight = (weight) => `${weight.toFixed(0)} kg`;
-
-export default WorkoutHistory; 
+export default WorkoutHistory;

--- a/frontend/src/components/WorkoutPlanner.js
+++ b/frontend/src/components/WorkoutPlanner.js
@@ -413,112 +413,77 @@ const WorkoutPlanner = ({ user }) => {
                       Add Exercise
                     </Button>
                   </Box>
-                  <TableContainer component={Paper} sx={{ boxShadow: 'none', bgcolor: 'transparent' }}>
-                    <Table size="small">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell sx={{ 
-                            fontSize: isMobile ? 11 : 13, 
-                            fontWeight: 600, 
-                            py: 1,
-                            bgcolor: 'background.default',
-                            borderBottom: '2px solid',
-                            borderColor: 'divider',
-                            pl: isMobile ? 1 : 2,
-                            pr: isMobile ? 1 : 2
-                          }}>
-                            Exercise
-                          </TableCell>
-                          <TableCell align="center" sx={{ 
-                            fontSize: isMobile ? 11 : 13, 
-                            fontWeight: 600, 
-                            py: 1,
-                            bgcolor: 'background.default',
-                            borderBottom: '2px solid',
-                            borderColor: 'divider',
-                            width: isMobile ? 40 : 50,
-                            minWidth: isMobile ? 40 : 50,
-                            maxWidth: isMobile ? 40 : 50
-                          }}>
-                          </TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {(program && Array.isArray(program[day]) ? program[day] : []).map((ex, idx) => (
-                          <TableRow key={idx} sx={{ '& .MuiTableCell-root': { py: 1 } }}>
-                            <TableCell sx={{ 
-                              fontSize: isMobile ? 11 : 13,
-                              borderBottom: '1px solid',
-                              borderColor: 'divider',
-                              pl: isMobile ? 1 : 2,
-                              pr: isMobile ? 1 : 2,
-                              cursor: 'pointer',
-                              '&:hover': {
-                                bgcolor: 'background.default'
-                              }
+                  <Box>
+                    {(program && Array.isArray(program[day]) ? program[day] : []).length === 0 && (
+                      <Typography sx={{ fontSize: 12, color: 'text.secondary', fontStyle: 'italic', py: 1 }}>
+                        Rest day — no exercises planned
+                      </Typography>
+                    )}
+                    {(program && Array.isArray(program[day]) ? program[day] : []).map((ex, idx) => (
+                      <Box
+                        key={idx}
+                        onClick={() => handleEditExercise(day, idx, ex)}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: 1,
+                          py: 1,
+                          borderBottom: '1px solid',
+                          borderColor: 'divider',
+                          cursor: 'pointer',
+                          '&:last-of-type': { borderBottom: 'none' },
+                          '&:active': { backgroundColor: 'rgba(255,255,255,0.03)' },
+                        }}
+                      >
+                        <Box sx={{ minWidth: 0 }}>
+                          <Typography
+                            sx={{
+                              fontSize: 13,
+                              fontWeight: 500,
+                              color: ex.exercise ? 'text.primary' : 'text.secondary',
+                              fontStyle: ex.exercise ? 'normal' : 'italic',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
                             }}
-                            onClick={() => handleEditExercise(day, idx, ex)}
+                          >
+                            {ex.exercise || 'Tap to choose exercise'}
+                          </Typography>
+                          {exerciseMap[ex.exercise]?.muscle_group && (
+                            <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+                              {exerciseMap[ex.exercise].muscle_group}
+                            </Typography>
+                          )}
+                        </Box>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
+                          {ex.exercise && (
+                            <Box
+                              sx={{
+                                fontSize: 11,
+                                fontWeight: 600,
+                                color: 'primary.main',
+                                border: '1px solid',
+                                borderColor: 'rgba(0, 212, 170, 0.35)',
+                                borderRadius: 10,
+                                px: 1,
+                                py: 0.25,
+                                whiteSpace: 'nowrap',
+                              }}
                             >
-                              <Box>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-                                  <Typography 
-                                    variant="body2" 
-                                    sx={{ 
-                                      fontWeight: 500,
-                                      color: ex.exercise ? 'text.primary' : 'text.secondary',
-                                      fontStyle: ex.exercise ? 'normal' : 'italic'
-                                    }}
-                                  >
-                                    {ex.exercise || 'Click to add exercise'}
-                                  </Typography>
-                                  {ex.exercise && (
-                                    <Typography 
-                                      variant="body2" 
-                                      color="text.secondary"
-                                      sx={{ 
-                                        fontWeight: 500,
-                                        whiteSpace: 'nowrap'
-                                      }}
-                                    >
-                                      • {ex.sets || 3} sets × {ex.targetReps || 8} reps
-                                    </Typography>
-                                  )}
-                                </Box>
-                                {exerciseMap[ex.exercise]?.muscle_group && (
-                                  <Typography 
-                                    variant="caption" 
-                                    color="text.secondary" 
-                                    sx={{ 
-                                      fontSize: 11,
-                                      fontWeight: 500,
-                                      display: 'block'
-                                    }}
-                                  >
-                                    {exerciseMap[ex.exercise].muscle_group}
-                                  </Typography>
-                                )}
-                              </Box>
-                            </TableCell>
-                            <TableCell align="center" sx={{ 
-                              fontSize: isMobile ? 11 : 13,
-                              borderBottom: '1px solid',
-                              borderColor: 'divider',
-                              width: isMobile ? 40 : 50,
-                              minWidth: isMobile ? 40 : 50,
-                              maxWidth: isMobile ? 40 : 50
-                            }}>
-                              <IconButton onClick={(e) => {
-                                e.stopPropagation();
-                                handleRemoveExercise(day, idx);
-                              }} size="small" color="error" sx={{ p: 0.5 }}>
-                                <DeleteIcon sx={{ fontSize: '1rem' }} />
-                              </IconButton>
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
+                              {ex.sets || 3} × {ex.targetReps || 8}
+                            </Box>
+                          )}
+                          <IconButton onClick={(e) => {
+                            e.stopPropagation();
+                            handleRemoveExercise(day, idx);
+                          }} size="small" color="error" sx={{ p: 0.5, opacity: 0.7 }}>
+                            <DeleteIcon sx={{ fontSize: '1rem' }} />
+                          </IconButton>
+                        </Box>
+                      </Box>
+                    ))}
+                  </Box>
                 </CardContent>
               </Card>
             );
@@ -530,118 +495,66 @@ const WorkoutPlanner = ({ user }) => {
           <Typography variant="h6" fontWeight={600} gutterBottom sx={{ mb: 2, fontSize: 13 }}>
             Weekly Volume Analysis
           </Typography>
-          <TableContainer component={Paper} sx={{ boxShadow: 'none', bgcolor: 'transparent' }}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ 
-                    fontSize: isMobile ? 11 : 13, 
-                    fontWeight: 600, 
-                    py: 1,
-                    bgcolor: 'background.default',
-                    borderBottom: '2px solid',
-                    borderColor: 'divider'
-                  }}>
-                    Muscle Group
-                  </TableCell>
-                  <TableCell align="right" sx={{ 
-                    fontSize: isMobile ? 11 : 13, 
-                    fontWeight: 600, 
-                    py: 1,
-                    bgcolor: 'background.default',
-                    borderBottom: '2px solid',
-                    borderColor: 'divider'
-                  }}>
-                    Sets/Week
-                  </TableCell>
-                  <TableCell align="right" sx={{ 
-                    fontSize: isMobile ? 11 : 13, 
-                    fontWeight: 600, 
-                    py: 1,
-                    bgcolor: 'background.default',
-                    borderBottom: '2px solid',
-                    borderColor: 'divider'
-                  }}>
-                    Frequency
-                  </TableCell>
-                  <TableCell align="right" sx={{ 
-                    fontSize: isMobile ? 11 : 13, 
-                    fontWeight: 600, 
-                    py: 1,
-                    bgcolor: 'success.light', 
-                    color: 'success.contrastText',
-                    borderBottom: '2px solid',
-                    borderColor: 'divider'
-                  }}>
-                    Optimal Sets
-                  </TableCell>
-                  <TableCell align="right" sx={{ 
-                    fontSize: isMobile ? 11 : 13, 
-                    fontWeight: 600, 
-                    py: 1,
-                    bgcolor: 'success.light', 
-                    color: 'success.contrastText',
-                    borderBottom: '2px solid',
-                    borderColor: 'divider'
-                  }}>
-                    Optimal Freq.
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {Object.keys(weeklyVolume).length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={5} align="center" color="text.secondary" sx={{ fontSize: isMobile ? 12 : 13, py: 2 }}>
-                      No data
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  Object.entries(weeklyVolume).map(([mg, sets]) => (
-                    <TableRow key={mg} sx={{ '& .MuiTableCell-root': { py: 1 } }}>
-                      <TableCell sx={{ 
-                        fontSize: isMobile ? 11 : 13, 
-                        fontWeight: 500,
-                        borderBottom: '1px solid',
-                        borderColor: 'divider'
-                      }}>
-                        {mg}
-                      </TableCell>
-                      <TableCell align="right" sx={{ 
-                        fontSize: isMobile ? 11 : 13,
-                        borderBottom: '1px solid',
-                        borderColor: 'divider'
-                      }}>
-                        {sets}
-                      </TableCell>
-                      <TableCell align="right" sx={{ 
-                        fontSize: isMobile ? 11 : 13,
-                        borderBottom: '1px solid',
-                        borderColor: 'divider'
-                      }}>
-                        {weeklyFreq[mg]}
-                      </TableCell>
-                      <TableCell align="right" sx={{ 
-                        fontSize: isMobile ? 11 : 13,
-                        bgcolor: 'success.50',
-                        borderBottom: '1px solid',
-                        borderColor: 'divider'
-                      }}>
-                        {OPTIMAL_RANGES[mg]?.sets || '-'}
-                      </TableCell>
-                      <TableCell align="right" sx={{ 
-                        fontSize: isMobile ? 11 : 13,
-                        bgcolor: 'success.50',
-                        borderBottom: '1px solid',
-                        borderColor: 'divider'
-                      }}>
-                        {OPTIMAL_RANGES[mg]?.freq || '-'}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </TableContainer>
+          {Object.keys(weeklyVolume).length === 0 ? (
+            <Typography sx={{ fontSize: 13, color: 'text.secondary', textAlign: 'center', py: 2 }}>
+              No data
+            </Typography>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+              {Object.entries(weeklyVolume)
+                .sort((a, b) => b[1] - a[1])
+                .map(([mg, sets]) => {
+                  const optimal = OPTIMAL_RANGES[mg];
+                  let minOpt = 0, maxOpt = 0;
+                  const match = optimal?.sets?.match(/(\d+)[^\d]+(\d+)/);
+                  if (match) {
+                    minOpt = parseInt(match[1], 10);
+                    maxOpt = parseInt(match[2], 10);
+                  }
+                  const scaleMax = Math.max(sets, maxOpt) * 1.15 || 1;
+                  const inRange = !maxOpt || (sets >= minOpt && sets <= maxOpt);
+                  const barColor = inRange ? 'primary.main' : sets > maxOpt ? '#F09595' : '#FAC775';
+                  return (
+                    <Box key={mg}>
+                      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                        <Typography sx={{ fontSize: 12, fontWeight: 500 }}>{mg}</Typography>
+                        <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>
+                          {sets} sets{maxOpt ? ` / ${minOpt}–${maxOpt}` : ''} · {weeklyFreq[mg]}×wk{optimal?.freq ? ` / ${optimal.freq}` : ''}
+                        </Typography>
+                      </Box>
+                      <Box sx={{ position: 'relative', height: 14, borderRadius: 1, backgroundColor: 'rgba(255,255,255,0.04)', overflow: 'hidden' }}>
+                        {maxOpt > 0 && (
+                          <Box
+                            sx={{
+                              position: 'absolute',
+                              left: `${(minOpt / scaleMax) * 100}%`,
+                              width: `${((maxOpt - minOpt) / scaleMax) * 100}%`,
+                              top: 0,
+                              bottom: 0,
+                              backgroundColor: 'rgba(0, 212, 170, 0.14)',
+                            }}
+                          />
+                        )}
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            left: 0,
+                            top: 4,
+                            height: 6,
+                            width: `${(sets / scaleMax) * 100}%`,
+                            borderRadius: 3,
+                            backgroundColor: barColor,
+                          }}
+                        />
+                      </Box>
+                    </Box>
+                  );
+                })}
+              <Typography sx={{ fontSize: 10, color: 'text.secondary', mt: 0.5 }}>
+                Shaded band = optimal weekly sets · amber = below range, red = above range
+              </Typography>
+            </Box>
+          )}
         </CardContent>
       </Card>
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -116,33 +116,6 @@ const globalStyles = `
     outline-offset: 2px;
   }
   
-  /* Enhanced transitions */
-  .MuiButton-root,
-  .MuiCard-root,
-  .MuiPaper-root {
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-  
-  /* Glow effects for primary elements */
-  .MuiButton-contained {
-    position: relative;
-    overflow: hidden;
-  }
-  
-  .MuiButton-contained::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-    transition: left 0.5s;
-  }
-  
-  .MuiButton-contained:hover::before {
-    left: 100%;
-  }
 `;
 
 // Inject global styles

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -144,33 +144,29 @@ const components = {
     styleOverrides: {
       root: {
         borderRadius: 12,
-        padding: '12px 24px',
+        padding: '10px 20px',
         fontWeight: 600,
         boxShadow: 'none',
         textTransform: 'none',
         letterSpacing: '0.01em',
-        transition: 'all 0.2s ease-in-out',
+        transition: 'background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease',
         '&:hover': {
-          transform: 'translateY(-1px)',
-          boxShadow: '0 8px 25px rgba(0, 212, 170, 0.3)'
+          boxShadow: 'none'
         }
       },
       contained: {
-        background: `linear-gradient(135deg, ${colors.primary.main} 0%, ${colors.primary.light} 100%)`,
+        backgroundColor: colors.primary.main,
         '&:hover': {
-          background: `linear-gradient(135deg, ${colors.primary.dark} 0%, ${colors.primary.main} 100%)`,
-          transform: 'translateY(-1px)',
-          boxShadow: '0 8px 25px rgba(0, 212, 170, 0.4)'
+          backgroundColor: colors.primary.dark,
+          boxShadow: 'none'
         }
       },
       outlined: {
-        borderColor: colors.primary.main,
+        borderColor: 'rgba(0, 212, 170, 0.5)',
         color: colors.primary.main,
         '&:hover': {
-          backgroundColor: colors.primary.main,
-          color: colors.primary.contrastText,
-          transform: 'translateY(-1px)',
-          boxShadow: '0 8px 25px rgba(0, 212, 170, 0.3)'
+          borderColor: colors.primary.main,
+          backgroundColor: 'rgba(0, 212, 170, 0.08)'
         }
       }
     }
@@ -183,14 +179,14 @@ const components = {
           backgroundColor: colors.background.paper,
           '& fieldset': {
             borderColor: colors.divider,
-            borderWidth: '2px'
+            borderWidth: '1px'
           },
           '&:hover fieldset': {
             borderColor: colors.primary.light
           },
           '&.Mui-focused fieldset': {
             borderColor: colors.primary.main,
-            borderWidth: '2px'
+            borderWidth: '1px'
           }
         },
         '& .MuiInputLabel-root': {

--- a/schema.sql
+++ b/schema.sql
@@ -44,6 +44,19 @@ CREATE TABLE IF NOT EXISTS plans (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Create goals table (target 1RM by date, per exercise)
+CREATE TABLE IF NOT EXISTS goals (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  exercise_id INTEGER REFERENCES exercises(id) ON DELETE CASCADE,
+  start_date DATE NOT NULL,
+  target_date DATE NOT NULL,
+  start_one_rm REAL NOT NULL,
+  target_one_rm REAL NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Indexes for common query patterns (safe to run on an existing database)
 CREATE INDEX IF NOT EXISTS idx_workouts_user_date ON workouts(user_id, date);
 CREATE INDEX IF NOT EXISTS idx_workout_sets_workout ON workout_sets(workout_id);


### PR DESCRIPTION
## Summary

### Goal tracking
- New `goals` table + `/api/goals` endpoints (create with validation, live progress: current LOESS 1RM vs linear plan, on-track tolerance)
- Goals page under Menu: create goals with feasibility hint, progress cards with plan marker
- Dashed goal line on the Performance 1RM chart
- Add tab shows this week's on-plan weight for exercises with an active goal

### UI modernization
- Performance: stat cards (est. 1RM / best / 30-day change), themed charts, collapsed sets table
- History: 20-week consistency heatmap, month grouping, relative dates, muscle-group dots, expandable cards
- Plan: weekly volume as bars with optimal-range bands; lighter day rows with sets×reps chips
- Theme polish: flat buttons, thinner borders, removed shimmer effects, iOS translucent status bar + safe-area insets

## Deployment note
Requires the `goals` table on production Postgres (already created via Railway Data tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)