### PR TITLE
Fix goals not appearing after creation

### DIFF
--- a/frontend/src/components/Goals.js
+++ b/frontend/src/components/Goals.js
@@ -119,9 +119,9 @@ const Goals = () => {
         target_one_rm: parseFloat(formTarget),
         target_date: format(formDate, 'yyyy-MM-dd'),
       });
+      await fetchGoals();
       setCreateOpen(false);
       resetForm();
-      fetchGoals();
     } catch (err) {
       setError(err.response?.data?.error || 'Failed to create goal');
     } finally {


### PR DESCRIPTION
fetchGoals() was called without await after a successful POST, so the
dialog closed while the GET was still in flight. If the user opened
the dialog again before that GET completed, the newly created goal
appeared behind the dialog and looked like it hadn't persisted.

Move fetchGoals() before setCreateOpen/resetForm so the list is
populated while the "Saving..." state is still shown; the dialog
then closes to reveal the goal immediately.

https://claude.ai/code/session_01BvuGDHDqQpZ2tEVtFPNKjo